### PR TITLE
Resolve Heroku seeding bug

### DIFF
--- a/data/migrations/001_users.js
+++ b/data/migrations/001_users.js
@@ -12,6 +12,7 @@ exports.up = function(knex) {
                 ])
                 .notNullable()
                 .defaultsTo('visitor');
+            table.string('city', 30);
             table.timestamps(true, true);
         });
 };

--- a/data/seeds/001_users.js
+++ b/data/seeds/001_users.js
@@ -2,16 +2,18 @@ require('dotenv').config();
 
 const users = [
   {
-    email: 'tara_admin@gmail.com',
-    name: 'Tara',
-    password: process.env.ADMIN_PASSWORD,
-    role: 'administrator'
+    email: 'adam_admin@gmail.com',
+    name: 'Adam',
+    password: 'admin123',
+    role: 'administrator',
+    city: 'Salt Lake City'
   },
   {
     email: 'victor_visitor@gmail.com',
     name: 'Victor',
     password: 'visitor123',
-    role: 'visitor'
+    role: 'visitor',
+    city: 'West Valley City'
   }
 ];
 


### PR DESCRIPTION
- Changed admin seed user from hidden .env variable to a hardcoded password
This should resolve Heroku being unable to seed.

Unrelated to bug:
- Added 'city' column to 001_users.js migration
- Added city to seed users
